### PR TITLE
fix: Incorrect configuration information read

### DIFF
--- a/database/migrations/20181113071924_create_rules_table.php
+++ b/database/migrations/20181113071924_create_rules_table.php
@@ -29,7 +29,7 @@ class CreateRulesTable extends Migrator
      */
     protected function getDbConfig(): array
     {
-        $default = config('tauthz.database.connection') ?: config('database.default');
+        $default = config('tauthz.enforcers.basic.database.connection') ?: config('database.default');
 
         $config = config("database.connections.{$default}");
 

--- a/database/migrations/20181113071924_create_rules_table.php
+++ b/database/migrations/20181113071924_create_rules_table.php
@@ -29,10 +29,10 @@ class CreateRulesTable extends Migrator
      */
     protected function getDbConfig(): array
     {
-        $default =config('tauthz.default');
-        $connection= config("tauthz.enforcers.{$default}.database.connection") ?: config('database.default');
+        $default = config('tauthz.default');
+        $connection = config("tauthz.enforcers.{$default}.database.connection") ?: config('database.default');
         
-        $config = config("database.connections.{$default}");
+        $config = config("database.connections.{$connection}");
 
         if (0 == $config['deploy']) {
             $dbConfig = [

--- a/database/migrations/20181113071924_create_rules_table.php
+++ b/database/migrations/20181113071924_create_rules_table.php
@@ -29,8 +29,9 @@ class CreateRulesTable extends Migrator
      */
     protected function getDbConfig(): array
     {
-        $default = config('tauthz.enforcers.basic.database.connection') ?: config('database.default');
-
+        $default =config('tauthz.default');
+        $connection= config("tauthz.enforcers.{$default}.database.connection") ?: config('database.default');
+        
         $config = config("database.connections.{$default}");
 
         if (0 == $config['deploy']) {


### PR DESCRIPTION
读取配置信息键名有问题

不过读对了也没用，think-migration 有问题，已经向那边提交了 issue [数据库迁移脚本向不同的连接库迁移问题](https://github.com/top-think/think-migration/issues/70)